### PR TITLE
Fix anchors for document

### DIFF
--- a/core/abstract_tests/ATS_class_callback.adoc
+++ b/core/abstract_tests/ATS_class_callback.adoc
@@ -1,8 +1,7 @@
 [[ats_callback]]
-[requirement]
+[conformance_class]
 ====
 [%metadata]
-type:: conformanceclass
 label:: http://www.opengis.net/spec/ogcapi-processes-1/1.0/conf/callback
 subject:: <<rc_core,Requirements Class "Core">>
 classification:: Target Type:Web API

--- a/core/abstract_tests/ATS_class_core.adoc
+++ b/core/abstract_tests/ATS_class_core.adoc
@@ -1,8 +1,7 @@
 [[ats_core]]
-[requirement]
+[conformance_class]
 ====
 [%metadata]
-type:: conformanceclass
 label:: http://www.opengis.net/spec/ogcapi-processes-1/1.0/conf/core
 subject:: <<rc_core,Requirements Class "Core">>
 classification:: Target Type:Web API

--- a/core/abstract_tests/ATS_class_dismiss.adoc
+++ b/core/abstract_tests/ATS_class_dismiss.adoc
@@ -1,8 +1,7 @@
 [[ats_dismiss]]
-[requirement]
+[conformance_class]
 ====
 [%metadata]
-type:: conformanceclass
 label:: http://www.opengis.net/spec/ogcapi-processes-1/1.0/conf/dismiss
 subject:: <<rc_core,Requirements Class "Core">>
 classification:: Target Type:Web API

--- a/core/abstract_tests/ATS_class_html.adoc
+++ b/core/abstract_tests/ATS_class_html.adoc
@@ -1,8 +1,7 @@
 [[ats_html]]
-[requirement]
+[conformance_class]
 ====
 [%metadata]
-type:: conformanceclass
 label:: http://www.opengis.net/spec/ogcapi-processes-1/1.0/conf/dismiss
 subject:: <<rc_core,Requirements Class "Core">>
 inherit:: <<ats_core,Conformance Class "Core">>

--- a/core/abstract_tests/ATS_class_job-list.adoc
+++ b/core/abstract_tests/ATS_class_job-list.adoc
@@ -1,8 +1,7 @@
 [[ats_job-list]]
-[requirement]
+[conformance_class]
 ====
 [%metadata]
-type:: conformanceclass
 label:: http://www.opengis.net/spec/ogcapi-processes-1/1.0/conf/job-list
 subject:: <<rc_core,Requirements Class "Core">>
 classification:: Target Type:Web API

--- a/core/abstract_tests/ATS_class_json.adoc
+++ b/core/abstract_tests/ATS_class_json.adoc
@@ -1,8 +1,7 @@
 [[ats_json]]
-[requirement]
+[conformance_class]
 ====
 [%metadata]
-type:: conformanceclass
 label:: http://www.opengis.net/spec/ogcapi-processes-1/1.0/conf/json
 subject:: <<rc_core,Requirements Class "Core">>
 classification:: Target Type:Web API

--- a/core/abstract_tests/ATS_class_oas30.adoc
+++ b/core/abstract_tests/ATS_class_oas30.adoc
@@ -1,8 +1,7 @@
 [[ats_oas30]]
-[requirement]
+[conformance_class]
 ====
 [%metadata]
-type:: conformanceclass
 label:: http://www.opengis.net/spec/ogcapi-processes-1/1.0/conf/oas30
 subject:: <<rc_oas30,Requirements Class "OpenAPI Specification 3.0">>
 inherit:: <<ats_core,Conformance Class "Core">>

--- a/core/abstract_tests/ATS_class_ogc-process-description.adoc
+++ b/core/abstract_tests/ATS_class_ogc-process-description.adoc
@@ -1,8 +1,7 @@
 [[ats_ogc-process-description]]
-[requirement]
+[conformance_class]
 ====
 [%metadata]
-type:: conformanceclass
 label:: http://www.opengis.net/spec/ogcapi-processes-1/1.0/conf/ogc-process-description
 subject:: <<rc_ogc-process-description,Requirements Class "OGC Process Description">>
 classification:: Target Type:Web API

--- a/core/abstract_tests/callback/ATS_job-creation-callback.adoc
+++ b/core/abstract_tests/callback/ATS_job-creation-callback.adoc
@@ -1,8 +1,7 @@
 [[ats_callback_job-callback]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/callback/job-callback
 subject:: <<req_callback_job-callback,/req/callback/job-callback>>
 test-purpose:: Validate the passing of a subscriber-URL in an execute request.

--- a/core/abstract_tests/core/ATS_api-definition-op.adoc
+++ b/core/abstract_tests/core/ATS_api-definition-op.adoc
@@ -1,8 +1,7 @@
 [[ats_core_api-definition-op]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/core/api-definition-op
 subject:: <<req_core_api-definition-op,/req/core/api-definition-op>>
 test-purpose:: Validate that the API Definition document can be retrieved from the expected location.

--- a/core/abstract_tests/core/ATS_api-definition-success.adoc
+++ b/core/abstract_tests/core/ATS_api-definition-success.adoc
@@ -1,8 +1,7 @@
 [[ats_core_api-definition-success]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/core/api-definition-success
 subject:: <<req_core_api-definition-success,/req/core/api-definition-success>>
 test-purpose:: Validate that the API Definition complies with the required structure and contents.

--- a/core/abstract_tests/core/ATS_conformance-op.adoc
+++ b/core/abstract_tests/core/ATS_conformance-op.adoc
@@ -1,8 +1,7 @@
 [[ats_core_conformance-op]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/core/conformance-op
 subject:: <<req_core_conformance-op,/req/core/conformance-op>>
 test-purpose:: Validate that a Conformance Declaration can be retrieved from the expected location.

--- a/core/abstract_tests/core/ATS_conformance-success.adoc
+++ b/core/abstract_tests/core/ATS_conformance-success.adoc
@@ -1,8 +1,7 @@
 [[ats_core_conformance-success]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/core/conformance-success
 subject:: <<req_core_conformance-success,/req/core/conformance-success>>
 test-purpose:: Validate that the Conformance Declaration response complies with the required structure and contents.

--- a/core/abstract_tests/core/ATS_http.adoc
+++ b/core/abstract_tests/core/ATS_http.adoc
@@ -1,8 +1,7 @@
 [[ats_core_http]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/core/http
 subject:: <<req_core_http,/req/core/http>>
 test-purpose:: Validate that the resource paths advertised through the API conform with HTTP 1.1 and, where appropriate, TLS.

--- a/core/abstract_tests/core/ATS_job-creation-auto-execution-mode.adoc
+++ b/core/abstract_tests/core/ATS_job-creation-auto-execution-mode.adoc
@@ -1,8 +1,7 @@
 [[ats_core_job-creation-auto-execution-mode]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/core/job-creation-auto-execution-mode
 subject:: <<req_core_job-creation-op,/req/core/job-creation-op>>
 test-purpose:: Validate that the server correctly handles the execution mode for a process.

--- a/core/abstract_tests/core/ATS_job-creation-default-execution-mode.adoc
+++ b/core/abstract_tests/core/ATS_job-creation-default-execution-mode.adoc
@@ -1,8 +1,7 @@
 [[ats_core_job-creation-default-execution-mode]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/core/job-creation-default-execution-mode
 subject:: <<req_core_job-creation-op,/req/core/job-creation-op>>
 test-purpose:: Validate that the server correctly handles the default execution mode for a process.

--- a/core/abstract_tests/core/ATS_job-creation-default-outputs.adoc
+++ b/core/abstract_tests/core/ATS_job-creation-default-outputs.adoc
@@ -1,8 +1,7 @@
 [[ats_core_job-creation-default-outputs]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/core/job-creation-default-outputs
 subject:: <<req_core_job-creation-op,/req/core/job-creation-op>>
 test-purpose:: Validate that the server correctly handles the case where no `outputs` parameter is specified on an execute request.

--- a/core/abstract_tests/core/ATS_job-creation-input-array.adoc
+++ b/core/abstract_tests/core/ATS_job-creation-input-array.adoc
@@ -3,7 +3,7 @@
 ====
 [%metadata]
 label:: /conf/core/job-creation-input-array
-subject:: <<req_core_job-creations-input-array,/req/core/job-creation-input-array>>
+subject:: <<req_core_job-creation-input-array,/req/core/job-creation-input-array>>
 test-purpose:: Verify that the server correctly recognizes the encoding of parameter values for input parameters with a maximum cardinality greater than one.
 
 [.component,class=test method type]

--- a/core/abstract_tests/core/ATS_job-creation-input-array.adoc
+++ b/core/abstract_tests/core/ATS_job-creation-input-array.adoc
@@ -1,8 +1,7 @@
 [[ats_core_job-creation-input-array]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/core/job-creation-input-array
 subject:: <<req_core_job-creations-input-array,/req/core/job-creation-input-array>>
 test-purpose:: Verify that the server correctly recognizes the encoding of parameter values for input parameters with a maximum cardinality greater than one.

--- a/core/abstract_tests/core/ATS_job-creation-input-inline-bbox.adoc
+++ b/core/abstract_tests/core/ATS_job-creation-input-inline-bbox.adoc
@@ -1,8 +1,7 @@
 [[ats_core_job-creation-input-inline-bbox]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/core/job-creation-input-inline-bbox
 subject:: <<req_core_job-creation-input-inline-bbox,/req/core/job-creation-input-inline-bbox>>
 test-purpose:: Validate that inputs with a bounding box schema encoded in-line in an execute request are correctly processed.

--- a/core/abstract_tests/core/ATS_job-creation-input-inline-bbox.adoc
+++ b/core/abstract_tests/core/ATS_job-creation-input-inline-bbox.adoc
@@ -30,7 +30,7 @@ For each identified process construct an execute request according to test <<ats
 
 [.component,class=step]
 --
-Verify that each process executes successfully according to the <<ats_job-creation-success,relevant requirement based on the combination of execute parameters>>.
+Verify that each process executes successfully according to the <<ats-job-creation-success-sync,relevant requirement based on the combination of execute parameters>>.
 --
 =====
 ====

--- a/core/abstract_tests/core/ATS_job-creation-input-inline-binary.adoc
+++ b/core/abstract_tests/core/ATS_job-creation-input-inline-binary.adoc
@@ -3,7 +3,7 @@
 ====
 [%metadata]
 label:: /conf/core/job-creation-input-inline-binary
-subject:: <<req_core_job-creations-input-binary,/req/core/job-creation-input-binary>>
+subject:: <<req_core_job-creation-input-binary,/req/core/job-creation-input-binary>>
 test-purpose:: Validate that binary input values encoded as base-64 string in-line in an execute request are correctly processes.
 
 [.component,class=test method type]

--- a/core/abstract_tests/core/ATS_job-creation-input-inline-binary.adoc
+++ b/core/abstract_tests/core/ATS_job-creation-input-inline-binary.adoc
@@ -1,8 +1,7 @@
 [[ats_core_job-creation-input-inline-binary]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/core/job-creation-input-inline-binary
 subject:: <<req_core_job-creations-input-binary,/req/core/job-creation-input-binary>>
 test-purpose:: Validate that binary input values encoded as base-64 string in-line in an execute request are correctly processes.

--- a/core/abstract_tests/core/ATS_job-creation-input-inline-mixed.adoc
+++ b/core/abstract_tests/core/ATS_job-creation-input-inline-mixed.adoc
@@ -1,8 +1,7 @@
 [[ats_core_job-creation-input-inline-mixed]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/core/job-creation-input-inline-mixed
 subject:: <<req_core_job-creation-input-inline-mixed,/req/core/job-creation-input-inline-mixed>>
 test-purpose:: Validate that inputs of mixed content encoded in-line in an execute request are correctly processed.

--- a/core/abstract_tests/core/ATS_job-creation-input-inline-object.adoc
+++ b/core/abstract_tests/core/ATS_job-creation-input-inline-object.adoc
@@ -1,8 +1,7 @@
 [[ats_core_job-creation-input-inline-object]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/core/job-creation-input-inline-object
 subject:: <<req_core_job-creation-input-inline-object,/req/core/job-creation-input-inline-object>>
 test-purpose:: Validate that inputs with a complex object schema encoded in-line in an execute request are correctly processed.

--- a/core/abstract_tests/core/ATS_job-creation-input-inline.adoc
+++ b/core/abstract_tests/core/ATS_job-creation-input-inline.adoc
@@ -1,8 +1,7 @@
 [[ats_core_job-creation-input-inline]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/core/job-creation-input-inline
 subject:: <<req_core_job-creations-input-inline,/req/core/job-creation-input-inline>>
 test-purpose:: Validate in-line process input values are validated against the corresponding schema from the process description.

--- a/core/abstract_tests/core/ATS_job-creation-input-inline.adoc
+++ b/core/abstract_tests/core/ATS_job-creation-input-inline.adoc
@@ -3,7 +3,7 @@
 ====
 [%metadata]
 label:: /conf/core/job-creation-input-inline
-subject:: <<req_core_job-creations-input-inline,/req/core/job-creation-input-inline>>
+subject:: <<req_core_job-creation-input-inline,/req/core/job-creation-input-inline>>
 test-purpose:: Validate in-line process input values are validated against the corresponding schema from the process description.
 
 [.component,class=test method type]

--- a/core/abstract_tests/core/ATS_job-creation-input-ref.adoc
+++ b/core/abstract_tests/core/ATS_job-creation-input-ref.adoc
@@ -1,8 +1,7 @@
 [[ats_core_job-creation-input-ref]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/core/job-creation-input-ref
 subject:: <<req_core_job-creation-input-ref,/req/core/job-creation-input-ref>>
 test-purpose:: Validate that input values specified by reference in an execute request are correctly processed.

--- a/core/abstract_tests/core/ATS_job-creation-input-validation.adoc
+++ b/core/abstract_tests/core/ATS_job-creation-input-validation.adoc
@@ -1,8 +1,7 @@
 [[ats_core_job-creation-input-validation]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/core/job-creation-input-validation
 subject:: <<req_core_job-creation-input-validation,/req/core/job-creation-input-validation>>
 test-purpose:: Verify that the server correctly validates process input values according to the definition obtained from the <<sc_process_description,process description>>.

--- a/core/abstract_tests/core/ATS_job-creation-inputs.adoc
+++ b/core/abstract_tests/core/ATS_job-creation-inputs.adoc
@@ -1,8 +1,7 @@
 [[ats_core_job-creation-inputs]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/core/job-creation-inputs
 subject:: <<req_core_job-creation-inputs,/req/core/job-creation-inputs>>
 test-purpose:: Validate that servers can accept input values both inline and by reference.

--- a/core/abstract_tests/core/ATS_job-creation-op.adoc
+++ b/core/abstract_tests/core/ATS_job-creation-op.adoc
@@ -16,7 +16,7 @@ Manual Inspection
 
 [.component,class=step]
 --
-Issue an HTTP POST request to the URL '/processes/{processID}/execution' for each execution mode according to requirements <<req_core_job-creation-default-execution-mode,/conf/core/job-creation-default-execution-mode>> or <<req_core_job-creation-auto-execution-mode,/conf/core/job-creation-auto-execution-mode>>.
+Issue an HTTP POST request to the URL '/processes/{processID}/execution' for each execution mode according to requirements <<ats_core_job-creation-default-execution-mode,/conf/core/job-creation-default-execution-mode>> or <<ats_core_job-creation-auto-execution-mode,/conf/core/job-creation-auto-execution-mode>>.
 --
 
 [.component,class=step]

--- a/core/abstract_tests/core/ATS_job-creation-op.adoc
+++ b/core/abstract_tests/core/ATS_job-creation-op.adoc
@@ -1,8 +1,7 @@
 [[ats_core_job-creation-op]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/core/job-creation-op
 subject:: <<req_core_job-creation-op,/req/core/job-creation-op>>
 test-purpose:: Validate the creation of a new job.

--- a/core/abstract_tests/core/ATS_job-creation-request.adoc
+++ b/core/abstract_tests/core/ATS_job-creation-request.adoc
@@ -1,8 +1,7 @@
 [[ats_core_job-creation-request]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/core/job-creation-request
 subject:: <<req_core_job-creation-request,/req/core/job-creation-request>>
 test-purpose:: Validate that the body of a job creation operation complies with the required structure and contents.

--- a/core/abstract_tests/core/ATS_job-creation-success-async.adoc
+++ b/core/abstract_tests/core/ATS_job-creation-success-async.adoc
@@ -1,8 +1,7 @@
 [[ats_core_job-creation-success-async]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/core/job-creation-success-async
 subject:: <<req_core_job-creation-success-async,/req/core/job-creation-success-async>>
 test-purpose:: Validate the results of a job that has been created using the `async` execution mode.

--- a/core/abstract_tests/core/ATS_job-creation-success-sync-document.adoc
+++ b/core/abstract_tests/core/ATS_job-creation-success-sync-document.adoc
@@ -5,7 +5,7 @@
 type:: abstracttest
 label:: /conf/core/job-creation-sync-document
 subject:: <<req_core_job-creation-sync-document,/req/core/job-creation-sync-document>>
-test-purpose:: Validate that the server responds as expected when synchronous execution is <<sc_execution_code,negotiated>> and the response type is `document`.
+test-purpose:: Validate that the server responds as expected when synchronous execution is <<sc_execution_mode,negotiated>> and the response type is `document`.
 
 [.component,class=test method type]
 --

--- a/core/abstract_tests/core/ATS_job-creation-success-sync-document.adoc
+++ b/core/abstract_tests/core/ATS_job-creation-success-sync-document.adoc
@@ -1,8 +1,7 @@
 [[ats_core_job-creation-sync-document]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/core/job-creation-sync-document
 subject:: <<req_core_job-creation-sync-document,/req/core/job-creation-sync-document>>
 test-purpose:: Validate that the server responds as expected when synchronous execution is <<sc_execution_mode,negotiated>> and the response type is `document`.

--- a/core/abstract_tests/core/ATS_job-creation-success-sync-raw-mixed-multi.adoc
+++ b/core/abstract_tests/core/ATS_job-creation-success-sync-raw-mixed-multi.adoc
@@ -1,8 +1,7 @@
 [[ats_core_job-creation-sync-raw-mixed-multi]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/core/job-creation-sync-raw-mixed-multi
 subject:: <<req_core_job-creation-sync-raw-mixed-multi,/req/core/job-creation-sync-raw-mixed-multi>>
 test-purpose:: Validate that the server responds as expected when synchronous execution is <<sc_execution_mode,negotiated>>, the response type is `raw` and the output transmission is a mix of `value` and `reference`.

--- a/core/abstract_tests/core/ATS_job-creation-success-sync-raw-ref.adoc
+++ b/core/abstract_tests/core/ATS_job-creation-success-sync-raw-ref.adoc
@@ -1,8 +1,7 @@
 [[ats_core_job-creation-sync-raw-ref]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/core/job-creation-sync-raw-ref
 subject:: <<req_core_job-creation-sync-raw-ref,/req/core/job-creation-sync-raw-ref>>
 test-purpose:: Validate that the server responds as expected when synchronous execution is <<sc_execution_mode,negotiated>>, the response type is `raw` and the transmission mode is `ref`.

--- a/core/abstract_tests/core/ATS_job-creation-success-sync-raw-value-multi.adoc
+++ b/core/abstract_tests/core/ATS_job-creation-success-sync-raw-value-multi.adoc
@@ -1,8 +1,7 @@
 [[ats_core_job-creation-sync-raw-value-multi]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/core/job-creation-sync-raw-value-multi
 subject:: <<req_core_job-creation-sync-raw-value-multi,/req/core/job-creation-sync-raw-value-multi>>
 test-purpose:: Validate that the server responds as expected when synchronous execution is <<sc_execution_mode,negotiated>>, the response type is `raw` and the output transmission is `value`.

--- a/core/abstract_tests/core/ATS_job-creation-success-sync-raw-value-one.adoc
+++ b/core/abstract_tests/core/ATS_job-creation-success-sync-raw-value-one.adoc
@@ -1,8 +1,7 @@
 [[ats_core_job-creation-sync-raw-value-one]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/core/job-creation-sync-raw-value-one
 subject:: <<req_core_job-creation-sync-raw-value-one,/req/core/job-creation-sync-raw-value-one>>
 test-purpose:: Validate that the server responds as expected when synchronous execution is <<sc_execution_mode,negotiated>>, a single output value is requested, the response type is `raw` and the output transmission is `value`.

--- a/core/abstract_tests/core/ATS_job-exception-no-such-job.adoc
+++ b/core/abstract_tests/core/ATS_job-exception-no-such-job.adoc
@@ -1,8 +1,7 @@
 [[ats_core_job-exception-no-such-job]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/core/job-exception-no-such-job
 subject:: <<req_core_job-exception-no-such-job,/req/core/job-exception-no-such-job>>
 test-purpose:: Validate that an invalid job identifier is handled correctly.

--- a/core/abstract_tests/core/ATS_job-op.adoc
+++ b/core/abstract_tests/core/ATS_job-op.adoc
@@ -1,8 +1,7 @@
 [[ats_core_job-op]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/core/job-op
 subject:: <<req_core_job,/req/core/job>>
 test-purpose:: Validate that the status info of a job can be retrieved.

--- a/core/abstract_tests/core/ATS_job-op.adoc
+++ b/core/abstract_tests/core/ATS_job-op.adoc
@@ -15,7 +15,7 @@ Manual Inspection
 =====
 [.component,class=step]
 --
-Create a job as per <<ats_core_job-creations-op,/req/core/job-creation-op>> and note the {jobID} assigned to the job.
+Create a job as per <<ats_core_job-creation-op,/req/core/job-creation-op>> and note the {jobID} assigned to the job.
 --
 
 [.component,class=step]

--- a/core/abstract_tests/core/ATS_job-results-exception-no-such-job.adoc
+++ b/core/abstract_tests/core/ATS_job-results-exception-no-such-job.adoc
@@ -3,7 +3,7 @@
 ====
 [%metadata]
 label:: /conf/core/job-results-failed
-subject:: <<req_core_job-results-exception-no-such-job,/req/core/job-results-exception-no-such-job>>
+subject:: <<req_core_job-results-exception_no-such-job,/req/core/job-results-exception-no-such-job>>
 test-purpose:: Validate that the job results retrieved using an invalid job identifier complies with the require structure and contents.
 
 [.component,class=test method type]

--- a/core/abstract_tests/core/ATS_job-results-exception-no-such-job.adoc
+++ b/core/abstract_tests/core/ATS_job-results-exception-no-such-job.adoc
@@ -1,8 +1,7 @@
 [[ats_core_job-results-exception-no-such-job]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/core/job-results-failed
 subject:: <<req_core_job-results-exception-no-such-job,/req/core/job-results-exception-no-such-job>>
 test-purpose:: Validate that the job results retrieved using an invalid job identifier complies with the require structure and contents.

--- a/core/abstract_tests/core/ATS_job-results-exception-results-not-ready.adoc
+++ b/core/abstract_tests/core/ATS_job-results-exception-results-not-ready.adoc
@@ -1,8 +1,7 @@
 [[ats_core_job-results-exception-results-not-ready]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/core/job-results-exception-results-not-ready
 subject:: <<req_core_job-results-exception-results-not-ready,/req/core/job-results-exception-results-not-ready>>
 test-purpose:: Validate that the job results retrieved for an incomplete job complies with the require structure and contents.

--- a/core/abstract_tests/core/ATS_job-results-exception-results-not-ready.adoc
+++ b/core/abstract_tests/core/ATS_job-results-exception-results-not-ready.adoc
@@ -3,7 +3,7 @@
 ====
 [%metadata]
 label:: /conf/core/job-results-exception-results-not-ready
-subject:: <<req_core_job-results-exception-results-not-ready,/req/core/job-results-exception-results-not-ready>>
+subject:: <<req_core_job-results-exception_results-not-ready,/req/core/job-results-exception-results-not-ready>>
 test-purpose:: Validate that the job results retrieved for an incomplete job complies with the require structure and contents.
 
 [.component,class=test method type]

--- a/core/abstract_tests/core/ATS_job-results-failed.adoc
+++ b/core/abstract_tests/core/ATS_job-results-failed.adoc
@@ -1,8 +1,7 @@
 [[ats_core_job-results-failed]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/core/job-results-failed
 subject:: <<req_core_job-results-failed,/req/core/job-results-failed>>
 test-purpose:: Validate that the job results for a failed job complies with the require structure and contents.

--- a/core/abstract_tests/core/ATS_job-results-failed.adoc
+++ b/core/abstract_tests/core/ATS_job-results-failed.adoc
@@ -16,7 +16,7 @@ Manual Inspection
 
 [.component,class=step]
 --
-Create a job as per <<atd_core_job-creation-op,/req/core/job-creation-op>> but arrange a priori that the job will fail; note the {jobID} assigned to the job.
+Create a job as per <<ats_core_job-creation-op,/req/core/job-creation-op>> but arrange a priori that the job will fail; note the {jobID} assigned to the job.
 --
 
 [.component,class=step]

--- a/core/abstract_tests/core/ATS_job-results-op.adoc
+++ b/core/abstract_tests/core/ATS_job-results-op.adoc
@@ -1,8 +1,7 @@
 [[ats_core_job-results-op]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/core/job-results
 subject:: <<req_core_job-results,/req/core/job-results>>
 test-purpose:: Validate that the results of a job can be retrieved.

--- a/core/abstract_tests/core/ATS_job-results-op.adoc
+++ b/core/abstract_tests/core/ATS_job-results-op.adoc
@@ -30,7 +30,7 @@ Validate that the document was returned with a status code 200.
 
 [.component,class=step]
 --
-Validate the contents of the returned document using the test <<ats_job-results-success,/conf/core/job-results-success>>.
+Validate the contents of the returned document using the test <<ats-job-results-success,/conf/core/job-results-success>>.
 --
 =====
 ====

--- a/core/abstract_tests/core/ATS_job-results-op.adoc
+++ b/core/abstract_tests/core/ATS_job-results-op.adoc
@@ -30,7 +30,7 @@ Validate that the document was returned with a status code 200.
 
 [.component,class=step]
 --
-Validate the contents of the returned document using the test <<ats-job-results-success,/conf/core/job-results-success>>.
+Validate the contents of the returned document using the test <<ats_job-results-success,/conf/core/job-results-success>>.
 --
 =====
 ====

--- a/core/abstract_tests/core/ATS_job-results-success-async-document.adoc
+++ b/core/abstract_tests/core/ATS_job-results-success-async-document.adoc
@@ -1,8 +1,7 @@
 [[ats_core_job-results-async-document]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/core/job-results-async-document
 subject:: <<req_core_job-results-async-document,/req/core/job-results-async-document>>
 test-purpose:: Validate that the server responds as expected when the asynchronous execution is <<sc_execution_mode,negotiated>> and the response type is `document`.

--- a/core/abstract_tests/core/ATS_job-results-success-async-raw-mixed-multi.adoc
+++ b/core/abstract_tests/core/ATS_job-results-success-async-raw-mixed-multi.adoc
@@ -1,8 +1,7 @@
 [[ats_core_job-results-async-raw-mixed-multi]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/core/job-results-async-raw-mixed-multi
 subject:: <<req_core_job-results-async-raw-mixed-multi,/req/core/job-results-async-raw-mixed-multi>>
 test-purpose:: Validate that the server responds as expected when asynchronous execution is <<sc_execution_mode,negotiated>>, more than one output is requested, the response type is `raw` and the output transmission is a mix of `value` and `reference`.

--- a/core/abstract_tests/core/ATS_job-results-success-async-raw-ref.adoc
+++ b/core/abstract_tests/core/ATS_job-results-success-async-raw-ref.adoc
@@ -1,8 +1,7 @@
 [[ats_core_job-results-async-raw-ref]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/core/job-results-async-raw-ref
 subject:: <<req_core_job-results-async-raw-ref,/req/core/job-results-async-raw-ref>>
 test-purpose:: Validate that the server responds as expected when asynchronous execution is <,sc_execution_mode,negotiated>>, the response type is `raw` and the output transmission is `reference`.

--- a/core/abstract_tests/core/ATS_job-results-success-async-raw-value-multi.adoc
+++ b/core/abstract_tests/core/ATS_job-results-success-async-raw-value-multi.adoc
@@ -57,7 +57,7 @@ Inspect the headers of the synchronous response and see if a `Link` header is in
 
 [.component,class=step]
 --
-If the link exists, get the job status as per test <<ats_core_job-op,/conf/cor e/job-op>> and ensure that the job status is set to `successful`.
+If the link exists, get the job status as per test <<ats_core_job-op,/conf/core/job-op>> and ensure that the job status is set to `successful`.
 --
 
 [.component,class=step]

--- a/core/abstract_tests/core/ATS_job-results-success-async-raw-value-multi.adoc
+++ b/core/abstract_tests/core/ATS_job-results-success-async-raw-value-multi.adoc
@@ -1,8 +1,7 @@
 [[ats_core_job-results-async-raw-value-multi]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/core/job-results-async-raw-value-multi
 subject:: <<req_core_job-results-async-raw-value-multi,/req/core/job-results-async-raw-value-multi>>
 test-purpose:: Validate that the server responds as expected when asynchronous execution is <sc_execution_mode,negotiated>>, more than one output is requested, the response type is `raw` and the output transmission is `value`.

--- a/core/abstract_tests/core/ATS_job-results-success-async-raw-value-one.adoc
+++ b/core/abstract_tests/core/ATS_job-results-success-async-raw-value-one.adoc
@@ -1,8 +1,7 @@
 [[ats_core_job-results-async-raw-value-one]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/core/job-results-async-raw-value-one
 subject:: <<req_core_job-results-async-raw-value-one,/req/core/job-results-async-raw-value-one>>
 test-purpose:: Validate that the server responds as expected when asynchronous execution is <<sc_execution_mode,negotiated>>, one output is requested, the response type is `raw` and the output transmission is `value`.

--- a/core/abstract_tests/core/ATS_job-results-success-sync.adoc
+++ b/core/abstract_tests/core/ATS_job-results-success-sync.adoc
@@ -1,8 +1,7 @@
 [[ats_core_job-results-sync]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/core/job-results-sync
 subject:: <<req_core_job-results-sync,/req/core/job-results-sync>>
 test-purpose:: Validate that the server responds as expected when getting results from a job for a process that has been executed synchronously.

--- a/core/abstract_tests/core/ATS_job-results-success.adoc
+++ b/core/abstract_tests/core/ATS_job-results-success.adoc
@@ -1,4 +1,4 @@
-[[ats-job-results-success]]
+[[ats_job-results-success]]
 Retrieving the results of an asynchronously executed process depends on a number of parameters specified in the execute request.  The following table enumerates the relevant requirement that needs to be satisfied based on the various execute parameter combinations.
 
 [%unnumbered]

--- a/core/abstract_tests/core/ATS_job-success.adoc
+++ b/core/abstract_tests/core/ATS_job-success.adoc
@@ -1,8 +1,7 @@
 [[ats_core_job-success]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/core/job-success
 subject:: <<req_core_job-success,/req/core/job-success>>
 test-purpose:: Validate that the job status info complies with the require structure and contents.

--- a/core/abstract_tests/core/ATS_landingpage-op.adoc
+++ b/core/abstract_tests/core/ATS_landingpage-op.adoc
@@ -1,8 +1,7 @@
 [[ats_core_landingpage-op]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/core/landingpage-op
 subject:: <<req_core_landingpage-op,/req/core/landingpage-op>>
 test-purpose:: Validate that a landing page can be retrieved from the expected location.

--- a/core/abstract_tests/core/ATS_landingpage-success.adoc
+++ b/core/abstract_tests/core/ATS_landingpage-success.adoc
@@ -1,8 +1,7 @@
 [[ats_core_landingpage-success]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/core/landingpage-success
 subject:: <<req_core_landingpage-success,/req/core/landingpage-success>>
 test-purpose:: Validate that the landing page complies with the require structure and contents.

--- a/core/abstract_tests/core/ATS_process-exception-no-such-process.adoc
+++ b/core/abstract_tests/core/ATS_process-exception-no-such-process.adoc
@@ -1,8 +1,7 @@
 [[ats_core_process-exception-no-such-process]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/core/process-exception-no-such-process
 subject:: <<req_core_process-exception-no-such-process,/req/core/process-exception-no-such-process>>
 test-purpose:: Validate that an invalid process identifier is handled correctly.

--- a/core/abstract_tests/core/ATS_process-list-limit-def.adoc
+++ b/core/abstract_tests/core/ATS_process-list-limit-def.adoc
@@ -3,7 +3,7 @@
 ====
 [%metadata]
 label:: /conf/core/pl-limit-definition
-subject:: <<req_core-pl-limit-definition,/req/core/pl-limit-definition>>
+subject:: <<req_core_pl-limit-definition,/req/core/pl-limit-definition>>
 test-purpose:: Validate that the `limit` query parameter is constructed correctly.
 
 [.component,class=test method type]

--- a/core/abstract_tests/core/ATS_process-list-limit-def.adoc
+++ b/core/abstract_tests/core/ATS_process-list-limit-def.adoc
@@ -1,8 +1,7 @@
 [[ats_core_pl-limit-definition]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/core/pl-limit-definition
 subject:: <<req_core-pl-limit-definition,/req/core/pl-limit-definition>>
 test-purpose:: Validate that the `limit` query parameter is constructed correctly.

--- a/core/abstract_tests/core/ATS_process-list-limit-response.adoc
+++ b/core/abstract_tests/core/ATS_process-list-limit-response.adoc
@@ -1,8 +1,7 @@
 [[ats_core_pl-limit-response]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/core/pl-limit-response
 subject:: <<req_core_pl-limit-response,/req/core/pl-limit-response>>
 test-purpose:: Validate that the `limit` query parameter is processed correctly.

--- a/core/abstract_tests/core/ATS_process-list-links.adoc
+++ b/core/abstract_tests/core/ATS_process-list-links.adoc
@@ -1,8 +1,7 @@
 [[ats_core_pl-links]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/core/pl-links
 subject:: <<req_core_pl-links,/req/core/pl-links>>
 test-purpose:: Validate that the proper links are included in a response.

--- a/core/abstract_tests/core/ATS_process-list-op.adoc
+++ b/core/abstract_tests/core/ATS_process-list-op.adoc
@@ -1,4 +1,4 @@
-[[ats_core_process-list]]
+[[ats_core_process-list-op]]
 [abstract_test]
 ====
 [%metadata]

--- a/core/abstract_tests/core/ATS_process-list-op.adoc
+++ b/core/abstract_tests/core/ATS_process-list-op.adoc
@@ -1,8 +1,7 @@
 [[ats_core_process-list]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/core/process-list
 subject:: <<req_core_process-list,/req/core/process-list>>
 test-purpose:: Validate that information about the processes can be retrieved from the expected location.

--- a/core/abstract_tests/core/ATS_process-list-success.adoc
+++ b/core/abstract_tests/core/ATS_process-list-success.adoc
@@ -1,8 +1,7 @@
 [[ats_core_process-list-success]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/core/process-list-success
 subject:: <<req_core_process-list-success,/req/core/process-list-success>>
 test-purpose:: Validate that the process list content complies with the required structure and contents.

--- a/core/abstract_tests/core/ATS_process-op.adoc
+++ b/core/abstract_tests/core/ATS_process-op.adoc
@@ -1,8 +1,7 @@
 [[ats_core_process]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/core/process
 subject:: <<req_core_process,/req/core/process>>
 test-purpose:: Validate that a process description can be retrieved from the expected location.

--- a/core/abstract_tests/core/ATS_process-success.adoc
+++ b/core/abstract_tests/core/ATS_process-success.adoc
@@ -1,8 +1,7 @@
 [[ats_core_process-success]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/core/process-success
 subject:: <<req_core_process-success,/req/core/process-success>>
 test-purpose:: Validate that the content complies with the required structure and contents.

--- a/core/abstract_tests/dismiss/ATS_job-dismiss-op.adoc
+++ b/core/abstract_tests/dismiss/ATS_job-dismiss-op.adoc
@@ -1,8 +1,7 @@
 [[ats_dismiss_job-dismiss-op]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/dismiss/job-dismiss-op
 subject:: <<req_dismiss_job-dismiss-op,/req/dismiss/job-dismiss-op>>
 test-purpose:: Validate that a running job can be dismissed.

--- a/core/abstract_tests/dismiss/ATS_job-dismiss-success.adoc
+++ b/core/abstract_tests/dismiss/ATS_job-dismiss-success.adoc
@@ -1,8 +1,7 @@
 [[ats_dismiss_job-dismiss-success]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/dismiss/job-dismiss-success
 subject:: <<req_dismiss_job-dismiss-success,/req/dismiss/job-dismiss-success>>
 test-purpose:: Validate that the content returned when dismissing a job complies with the required structure and contents.

--- a/core/abstract_tests/html/ATS_content.adoc
+++ b/core/abstract_tests/html/ATS_content.adoc
@@ -1,8 +1,7 @@
 [[ats_html_content]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/html/content
 subject:: <<req_html_content,/req/html/content>>
 test-purpose:: Verify the content of an HTML document given an input document and schema.

--- a/core/abstract_tests/html/ATS_content.adoc
+++ b/core/abstract_tests/html/ATS_content.adoc
@@ -5,7 +5,7 @@
 type:: abstracttest
 label:: /conf/html/content
 subject:: <<req_html_content,/req/html/content>>
-test-purpose:: Verify the content of an HTML document given an input document and schema. 
+test-purpose:: Verify the content of an HTML document given an input document and schema.
 
 [.component,class=test method type]
 --
@@ -16,7 +16,7 @@ Manual Inspection
 =====
 [.component,class=step]
 --
-Validate that the document is an link:https://www.w3.org/TR/html5/[HTML 5 document]
+Validate that the document is an <<w3c-html5>> document
 --
 
 [.component,class=step]

--- a/core/abstract_tests/html/ATS_definition.adoc
+++ b/core/abstract_tests/html/ATS_definition.adoc
@@ -1,8 +1,7 @@
 [[ats_html_definition]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/html/definition
 subject:: <<req_html_definition,/req/html/definition>>
 test-purpose:: Verify support for HTML

--- a/core/abstract_tests/job-list/ATS_datetime-def.adoc
+++ b/core/abstract_tests/job-list/ATS_datetime-def.adoc
@@ -3,7 +3,7 @@
 ====
 [%metadata]
 label:: /conf/job-list/datetime-definition
-subject:: <<req_job-list-datetime-definition,/req/job-list/datetime-definition>>
+subject:: <<req_job-list_datetime-definition,/req/job-list/datetime-definition>>
 test-purpose:: Validate that the `datetime` query parameter is constructed correctly.
 
 [.component,class=test method type]

--- a/core/abstract_tests/job-list/ATS_datetime-def.adoc
+++ b/core/abstract_tests/job-list/ATS_datetime-def.adoc
@@ -1,8 +1,7 @@
 [[ats_job-list_datetime-definition]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/job-list/datetime-definition
 subject:: <<req_job-list-datetime-definition,/req/job-list/datetime-definition>>
 test-purpose:: Validate that the `datetime` query parameter is constructed correctly.

--- a/core/abstract_tests/job-list/ATS_datetime-response.adoc
+++ b/core/abstract_tests/job-list/ATS_datetime-response.adoc
@@ -1,8 +1,7 @@
 [[ats_job-list_datetime-response]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/job-list/datetime-response
 subject:: <<req_job-list_datetime-response,/req/job-list/datetime-response>>
 test-purpose:: Validate that the `datetime` query parameter is processed correctly.

--- a/core/abstract_tests/job-list/ATS_duration-def.adoc
+++ b/core/abstract_tests/job-list/ATS_duration-def.adoc
@@ -1,8 +1,7 @@
 [[ats_job-list_duration-definition]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/job-list/duration-definition
 subject:: <<req_job-list-duration-definition,/req/job-list/duration-definition>>
 test-purpose:: Validate that the `minDuration` and `maxDuration` query parameter are constructed correctly.

--- a/core/abstract_tests/job-list/ATS_duration-def.adoc
+++ b/core/abstract_tests/job-list/ATS_duration-def.adoc
@@ -3,7 +3,7 @@
 ====
 [%metadata]
 label:: /conf/job-list/duration-definition
-subject:: <<req_job-list-duration-definition,/req/job-list/duration-definition>>
+subject:: <<req_job-list_duration-definition,/req/job-list/duration-definition>>
 test-purpose:: Validate that the `minDuration` and `maxDuration` query parameter are constructed correctly.
 
 [.component,class=test method type]

--- a/core/abstract_tests/job-list/ATS_duration-response.adoc
+++ b/core/abstract_tests/job-list/ATS_duration-response.adoc
@@ -1,8 +1,7 @@
 [[ats_job-list_duration-response]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/job-list/duration-response
 subject:: <<req_job-list_duration-response,/req/job-list/duration-response>>
 test-purpose:: Validate that the `minDuration` and `maxDuration` query parameter are processed correctly.

--- a/core/abstract_tests/job-list/ATS_jl-limit-def.adoc
+++ b/core/abstract_tests/job-list/ATS_jl-limit-def.adoc
@@ -3,7 +3,7 @@
 ====
 [%metadata]
 label:: /conf/job-list/limit-definition
-subject:: <<req_job-list-limit-definition,/req/job-list/limit-definition>>
+subject:: <<req_job-list_limit-definition,/req/job-list/limit-definition>>
 test-purpose:: Validate that the `limit` query parameter is constructed correctly.
 
 [.component,class=test method type]

--- a/core/abstract_tests/job-list/ATS_jl-limit-def.adoc
+++ b/core/abstract_tests/job-list/ATS_jl-limit-def.adoc
@@ -1,8 +1,7 @@
 [[ats_job-list_limit-definition]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/job-list/limit-definition
 subject:: <<req_job-list-limit-definition,/req/job-list/limit-definition>>
 test-purpose:: Validate that the `limit` query parameter is constructed correctly.

--- a/core/abstract_tests/job-list/ATS_jl-limit-response.adoc
+++ b/core/abstract_tests/job-list/ATS_jl-limit-response.adoc
@@ -1,8 +1,7 @@
 [[ats_job-list_limit-response]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/job-list/limit-response
 subject:: <<req_job-list_limit-response,/req/job-list/limit-response>>
 test-purpose:: Validate that the `limit` query parameter is processed correctly.

--- a/core/abstract_tests/job-list/ATS_jl-links.adoc
+++ b/core/abstract_tests/job-list/ATS_jl-links.adoc
@@ -1,8 +1,7 @@
 [[ats_job-list_links]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/job-list/links
 subject:: <<req_job-list_links,/req/job-list/links>>
 test-purpose:: Validate that the proper links are included in a response.

--- a/core/abstract_tests/job-list/ATS_op.adoc
+++ b/core/abstract_tests/job-list/ATS_op.adoc
@@ -1,8 +1,7 @@
 [[ats_job-list_job-list-op]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/job-list/job-list-op
 subject:: <<req_job-list_job-list-op,/req/job-list/job-list-op>>
 test-purpose:: Validate that information about jobs can be retrieved from the expected location.

--- a/core/abstract_tests/job-list/ATS_processid-def.adoc
+++ b/core/abstract_tests/job-list/ATS_processid-def.adoc
@@ -3,7 +3,7 @@
 ====
 [%metadata]
 label:: /conf/job-list/processID-definition
-subject:: <<req_job-list-processID-definition,/req/job-list/processID-definition>>
+subject:: <<req_job-list_processID-definition,/req/job-list/processID-definition>>
 test-purpose:: Validate that the `processID` query parameter is constructed correctly.
 
 [.component,class=test method type]

--- a/core/abstract_tests/job-list/ATS_processid-def.adoc
+++ b/core/abstract_tests/job-list/ATS_processid-def.adoc
@@ -1,8 +1,7 @@
 [[ats_job-list_processID-definition]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/job-list/processID-definition
 subject:: <<req_job-list-processID-definition,/req/job-list/processID-definition>>
 test-purpose:: Validate that the `processID` query parameter is constructed correctly.

--- a/core/abstract_tests/job-list/ATS_processid-mandatory.adoc
+++ b/core/abstract_tests/job-list/ATS_processid-mandatory.adoc
@@ -1,8 +1,7 @@
 [[ats_job-list_processid-mandatory]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/job-list/processID-mandatory
 subject:: <<req_job-list_processID-mandatory,/req/job-list/processID-mandatory>>
 test-purpose:: Validate that the `processID` property is present in every job.

--- a/core/abstract_tests/job-list/ATS_processid-response.adoc
+++ b/core/abstract_tests/job-list/ATS_processid-response.adoc
@@ -1,8 +1,7 @@
 [[ats_job-list_processID-response]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/job-list/processID-response
 subject:: <<req_job-list_processID-response,/req/job-list/processID-response>>
 test-purpose:: Validate that the `processID` query parameter is processed correctly.

--- a/core/abstract_tests/job-list/ATS_processid-response.adoc
+++ b/core/abstract_tests/job-list/ATS_processid-response.adoc
@@ -1,9 +1,9 @@
-[[ats_job-list_processID-response]]
+[[ats_job-list_processid-response]]
 [abstract_test]
 ====
 [%metadata]
 label:: /conf/job-list/processID-response
-subject:: <<req_job-list_processID-response,/req/job-list/processID-response>>
+subject:: <<req_job-list_processid-response,/req/job-list/processID-response>>
 test-purpose:: Validate that the `processID` query parameter is processed correctly.
 
 [.component,class=test method type]

--- a/core/abstract_tests/job-list/ATS_status-def.adoc
+++ b/core/abstract_tests/job-list/ATS_status-def.adoc
@@ -1,8 +1,7 @@
 [[ats_job-list_status-definition]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/job-list/status-definition
 subject:: <<req_job-list-status-definition,/req/job-list/status-definition>>
 test-purpose:: Validate that the `status` query parameter is constructed correctly.

--- a/core/abstract_tests/job-list/ATS_status-def.adoc
+++ b/core/abstract_tests/job-list/ATS_status-def.adoc
@@ -3,7 +3,7 @@
 ====
 [%metadata]
 label:: /conf/job-list/status-definition
-subject:: <<req_job-list-status-definition,/req/job-list/status-definition>>
+subject:: <<req_job-list_status-definition,/req/job-list/status-definition>>
 test-purpose:: Validate that the `status` query parameter is constructed correctly.
 
 [.component,class=test method type]

--- a/core/abstract_tests/job-list/ATS_status-response.adoc
+++ b/core/abstract_tests/job-list/ATS_status-response.adoc
@@ -1,8 +1,7 @@
 [[ats_job-list_status-response]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/job-list/status-response
 subject:: <<req_job-list_status-response,/req/job-list/status-response>>
 test-purpose:: Validate that the `status` query parameter is processed correctly.

--- a/core/abstract_tests/job-list/ATS_success.adoc
+++ b/core/abstract_tests/job-list/ATS_success.adoc
@@ -1,8 +1,7 @@
 [[ats_job-list_job-list-success]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/job-list/job-list-success
 subject:: <<req_job-list_job-list-success,/req/job-list/job-list-success>>
 test-purpose:: Validate that the job list content complies with the required structure and contents.

--- a/core/abstract_tests/job-list/ATS_type-def.adoc
+++ b/core/abstract_tests/job-list/ATS_type-def.adoc
@@ -1,8 +1,7 @@
 [[ats_job-list_type-definition]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/job-list/type-definition
 subject:: <<req_job-list-type-definition,/req/job-list/type-definition>>
 test-purpose:: Validate that the `type` query parameter is constructed correctly.

--- a/core/abstract_tests/job-list/ATS_type-def.adoc
+++ b/core/abstract_tests/job-list/ATS_type-def.adoc
@@ -3,7 +3,7 @@
 ====
 [%metadata]
 label:: /conf/job-list/type-definition
-subject:: <<req_job-list-type-definition,/req/job-list/type-definition>>
+subject:: <<req_job-list_type-definition,/req/job-list/type-definition>>
 test-purpose:: Validate that the `type` query parameter is constructed correctly.
 
 [.component,class=test method type]

--- a/core/abstract_tests/job-list/ATS_type-response.adoc
+++ b/core/abstract_tests/job-list/ATS_type-response.adoc
@@ -1,8 +1,7 @@
 [[ats_job-list_type-response]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/job-list/type-response
 subject:: <<req_job-list_type-response,/req/job-list/type-response>>
 test-purpose:: Validate that the `type` query parameter is processed correctly.

--- a/core/abstract_tests/json/ATS_definition.adoc
+++ b/core/abstract_tests/json/ATS_definition.adoc
@@ -1,8 +1,7 @@
 
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/json/definition
 subject:: <<req_json_definition,/req/json/definition>>
 test-purpose:: Verify support for JSON.

--- a/core/abstract_tests/oas30/ATS_completeness.adoc
+++ b/core/abstract_tests/oas30/ATS_completeness.adoc
@@ -1,11 +1,10 @@
 [[ats_oas30_completeness]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/oas30/completeness
 subject:: <<req_oas30_completeness,/req/oas30/completeness>>
-test-purpose:: Verify the completeness of an OpenAPI document. 
+test-purpose:: Verify the completeness of an OpenAPI document.
 
 [.component,class=test method type]
 --

--- a/core/abstract_tests/oas30/ATS_definition-1.adoc
+++ b/core/abstract_tests/oas30/ATS_definition-1.adoc
@@ -1,8 +1,7 @@
 [[ats_oas30_oas-definition-1]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/oas30/oas-definition-1
 subject:: <<req_oas30_oas-definition-1,/req/oas30/oas-definition-1>>
 test-purpose:: Verify that JSON and HTML versions of the OpenAPI document are available.

--- a/core/abstract_tests/oas30/ATS_definition-2.adoc
+++ b/core/abstract_tests/oas30/ATS_definition-2.adoc
@@ -1,8 +1,7 @@
 [[ats_oas30_oas-definition-2]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/oas30/oas-definition-2
 subject:: <<req_oas30_oas-definition-2,/req/oas30/oas-definition-2>>
 test-purpose:: Verify that the OpenAPI document is valid JSON.

--- a/core/abstract_tests/oas30/ATS_definition-2.adoc
+++ b/core/abstract_tests/oas30/ATS_definition-2.adoc
@@ -5,7 +5,7 @@
 type:: abstracttest
 label:: /conf/oas30/oas-definition-2
 subject:: <<req_oas30_oas-definition-2,/req/oas30/oas-definition-2>>
-test-purpose:: Verify that the OpenAPI document is valid JSON. 
+test-purpose:: Verify that the OpenAPI document is valid JSON.
 
 [.component,class=test method type]
 --
@@ -16,7 +16,7 @@ Manual Inspection
 =====
 [.component,class=step]
 --
-Verify that the JSON representation conforms to the <<OpenAPI,OpenAPI Specification, version 3.0>>.
+Verify that the JSON representation conforms to the <<OpenAPI-Spec,OpenAPI Specification, version 3.0>>.
 --
 =====
 ====

--- a/core/abstract_tests/oas30/ATS_exception-codes.adoc
+++ b/core/abstract_tests/oas30/ATS_exception-codes.adoc
@@ -1,11 +1,10 @@
 [[ats_oas30_exceptions-codes]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/oas30/exceptions-codes
 subject:: <<req_oas30_exceptions-codes,/req/oas30/exceptions-codes>>
-test-purpose:: Verify that the OpenAPI document fully describes potential exception codes. 
+test-purpose:: Verify that the OpenAPI document fully describes potential exception codes.
 
 [.component,class=test method type]
 --

--- a/core/abstract_tests/oas30/ATS_oas-impl.adoc
+++ b/core/abstract_tests/oas30/ATS_oas-impl.adoc
@@ -1,11 +1,10 @@
 [[ats_oas30_oas-impl]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/oas30/oas-impl
 subject:: <<req_oas30_oas-impl,/req/oas30/oas-impl>>
-test-purpose:: Verify that all capabilities specified in the OpenAPI definition are implemented by the API. 
+test-purpose:: Verify that all capabilities specified in the OpenAPI definition are implemented by the API.
 
 [.component,class=test method type]
 --

--- a/core/abstract_tests/oas30/ATS_security.adoc
+++ b/core/abstract_tests/oas30/ATS_security.adoc
@@ -1,11 +1,10 @@
 [[ats_oas30_security]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/oas30/security
 subject:: <<req_oas30_security,/req/oas30/security>>
-test-purpose:: Verify that any authentication protocols implemented by the API are documented in the OpenAPI document. 
+test-purpose:: Verify that any authentication protocols implemented by the API are documented in the OpenAPI document.
 
 [.component,class=test method type]
 --

--- a/core/abstract_tests/ogc-process-description/ATS_input-def.adoc
+++ b/core/abstract_tests/ogc-process-description/ATS_input-def.adoc
@@ -1,8 +1,7 @@
 [[ats_ogc-process-description_input-def]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/ogc-process-description/input-def
 subject:: <<req_ogc-process-description_input-def,/req/ogc-process-description/input-def>>
 test-purpose:: Verify that the definition of each input for each process complies with the required structure and contents.

--- a/core/abstract_tests/ogc-process-description/ATS_input-mixed-type.adoc
+++ b/core/abstract_tests/ogc-process-description/ATS_input-mixed-type.adoc
@@ -1,8 +1,7 @@
 [[ats_ogc-process-description_input-mixed-type]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/ogc-process-description/input-mixed-type
 subject:: <<req_ogc-process-description_input-mixed-type,/req/ogc-process-description/input-mixed-type>>
 test-purpose:: Validate that each input of mixed type complies with the required structure and contents.

--- a/core/abstract_tests/ogc-process-description/ATS_inputs-def.adoc
+++ b/core/abstract_tests/ogc-process-description/ATS_inputs-def.adoc
@@ -1,8 +1,7 @@
 [[ats_ogc-process-description_inputs-def]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/ogc-process-description/inputs-def
 subject:: <<req_ogc-process-description_inputs-def,/req/ogc-process-description/inputs-def>>
 test-purpose:: Verify that the definition of `inputs` for each process complies with the required structure and contents.

--- a/core/abstract_tests/ogc-process-description/ATS_json-encoding.adoc
+++ b/core/abstract_tests/ogc-process-description/ATS_json-encoding.adoc
@@ -1,8 +1,7 @@
 [[ats_ogc-process-description_json-encoding]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/ogc-process-description/json-encoding
 subject:: <<req_ogc-process-description_json-encoding,/req/ogc-process-description/json-encoding>>
 test-purpose:: Verify that a JSON-encoded OGC Process Description complies with the required structure and contents.

--- a/core/abstract_tests/ogc-process-description/ATS_output-def.adoc
+++ b/core/abstract_tests/ogc-process-description/ATS_output-def.adoc
@@ -1,8 +1,7 @@
 [[ats_ogc-process-description_output-def]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/ogc-process-description/output-def
 subject:: <<req_ogc-process-description_output-def,/req/ogc-process-description/output-def>>
 test-purpose:: Verify that the definition of each output for each process complies with the required structure and contents.

--- a/core/abstract_tests/ogc-process-description/ATS_output-mixed-type.adoc
+++ b/core/abstract_tests/ogc-process-description/ATS_output-mixed-type.adoc
@@ -1,8 +1,7 @@
 [[ats_ogc-process-description_output-mixed-type]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/ogc-process-description/output-mixed-type
 subject:: <<req_ogc-process-description_output-mixed-type,/req/ogc-process-description/output-mixed-type>>
 test-purpose:: Validate that each output of mixed type complies with the required structure and contents.

--- a/core/abstract_tests/ogc-process-description/ATS_outputs-def.adoc
+++ b/core/abstract_tests/ogc-process-description/ATS_outputs-def.adoc
@@ -1,8 +1,7 @@
 [[ats_ogc-process-description_outputs-def]]
-[requirement]
+[abstract_test]
 ====
 [%metadata]
-type:: abstracttest
 label:: /conf/ogc-process-description/outputs-def
 subject:: <<req_ogc-process-description_outputs-def,/req/ogc-process-description/outputs-def>>
 test-purpose:: Verify that the definition of `outputs` for each process complies with the required structure and contents.

--- a/core/requirements/core/REQ_process-exception-no-such-process.adoc
+++ b/core/requirements/core/REQ_process-exception-no-such-process.adoc
@@ -1,4 +1,4 @@
-[[req_core_no-such-process]]
+[[req_core_process-exception-no-such-process]]
 [requirement]
 ====
 [%metadata]

--- a/core/requirements/core/REQ_process-execute-input-inline-binary.adoc
+++ b/core/requirements/core/REQ_process-execute-input-inline-binary.adoc
@@ -1,4 +1,4 @@
-[req_core_process-execute-input-inline-binary]]
+[[req_core_process-execute-input-inline-binary]]
 [requirement]
 ====
 [%metadata]

--- a/core/requirements/html/REQ_content.adoc
+++ b/core/requirements/html/REQ_content.adoc
@@ -6,7 +6,7 @@ label:: /req/html/content
 
 
 Every `200`-response of the server with the media type "text/html" SHALL be a
-link:https://www.w3.org/TR/html5/[HTML 5 document] that includes the following
+<<w3c-html5>> document that includes the following
 information in the HTML body:
 
 * all information identified in the schemas of the

--- a/core/requirements/job-list/REQ_jl-limit-def.adoc
+++ b/core/requirements/job-list/REQ_jl-limit-def.adoc
@@ -3,6 +3,7 @@
 ====
 [%metadata]
 label:: /req/job-list/limit-definition
+
 [.component,class=part]
 --
 The operation SHALL support a parameter `limit` with the following characteristics (using an OpenAPI Specification 3.0 fragment):

--- a/core/requirements/oas30/REQ_oas-definition-2.adoc
+++ b/core/requirements/oas30/REQ_oas-definition-2.adoc
@@ -6,5 +6,5 @@ label:: /req/oas30/oas-definition-2
 
 
 The JSON representation SHALL conform to the
-<<OpenAPI,OpenAPI Specification, version 3.0>>.
+<<OpenAPI-Spec,OpenAPI Specification, version 3.0>>.
 ====

--- a/core/requirements/ogc-process-description/REQ_input-def.adoc
+++ b/core/requirements/ogc-process-description/REQ_input-def.adoc
@@ -15,6 +15,6 @@ The value of the `schema` parameter SHALL be a JSON fragment that validates acco
 
 [.component,class=part]
 --
-Servers SHALL use this schema fragment to validate the components of a <<sc_process_input,process input>> in an <<execute-request-body,execute request>> that is an instance of <<input-schema,inputValue.yaml>>.
+Servers SHALL use this schema fragment to validate the components of a <<sc_process_inputs,process input>> in an <<execute-request-body,execute request>> that is an instance of <<input-value-schema,inputValue.yaml>>.
 --
 ====

--- a/core/requirements/ogc-process-description/REQ_output-def.adoc
+++ b/core/requirements/ogc-process-description/REQ_output-def.adoc
@@ -5,7 +5,7 @@
 label:: /req/ogc-process-description/output-def
 [.component,class=part]
 --
-The schema of each <<sc_process_outputs-value-schema,process **output**>> SHALL be specified using the `schema` parameter.
+The schema of each <<sc_process_outputs,process **output**>> SHALL be specified using the `schema` parameter.
 --
 
 [.component,class=part]

--- a/core/requirements/requirements_class_callback.adoc
+++ b/core/requirements/requirements_class_callback.adoc
@@ -1,8 +1,7 @@
 [[rc_callback]]
-[requirement]
+[requirements_class]
 ====
 [%metadata]
-type:: class
 label:: http://www.opengis.net/spec/ogcapi-processes-1/1.0/req/callback
 obligation:: requirement
 subject:: Web API

--- a/core/requirements/requirements_class_core.adoc
+++ b/core/requirements/requirements_class_core.adoc
@@ -1,8 +1,7 @@
 [[rc_core]]
-[requirement]
+[requirements_class]
 ====
 [%metadata]
-type:: class
 label:: http://www.opengis.net/spec/ogcapi-processes-1/1.0/req/core
 obligation:: requirement
 subject:: Web API

--- a/core/requirements/requirements_class_core.adoc
+++ b/core/requirements/requirements_class_core.adoc
@@ -9,5 +9,5 @@ subject:: Web API
 inherit:: http://www.opengis.net/spec/ogcapi_common-1/1.0/req/core[API - Common Core]
 inherit:: <<rfc2616,RFC 2616 (HTTP/1.1)>>
 inherit:: <<rfc2818,RFC 2818 (HTTP over TLS)>>
-inherit:: <<rfc5988,RFC 8288 (Web Linking)>>
+inherit:: <<rfc8288,RFC 8288 (Web Linking)>>
 ====

--- a/core/requirements/requirements_class_dismiss.adoc
+++ b/core/requirements/requirements_class_dismiss.adoc
@@ -1,8 +1,7 @@
 [[rc_dismiss]]
-[requirement]
+[requirements_class]
 ====
 [%metadata]
-type:: class
 label:: http://www.opengis.net/spec/ogcapi-processes-1/1.0/req/dismiss
 obligation:: requirement
 subject:: Web API

--- a/core/requirements/requirements_class_html.adoc
+++ b/core/requirements/requirements_class_html.adoc
@@ -8,5 +8,5 @@ obligation:: requirement
 subject:: Web API
 inherit:: <<rc_core,OGC API - Processes Core>>
 inherit:: http://www.opengis.net/spec/ogcapi_common/1.0/req/html[API - Common HTML]
-inherit:: <<HTML5,HTML5>>
+inherit:: <<w3c-html5>>
 ====

--- a/core/requirements/requirements_class_html.adoc
+++ b/core/requirements/requirements_class_html.adoc
@@ -1,8 +1,7 @@
 [[rc_html]]
-[requirement]
+[requirements_class]
 ====
 [%metadata]
-type:: class
 label:: http://www.opengis.net/spec/ogcapi-processes-1/1.0/req/html
 obligation:: requirement
 subject:: Web API

--- a/core/requirements/requirements_class_job-list.adoc
+++ b/core/requirements/requirements_class_job-list.adoc
@@ -1,8 +1,7 @@
 [[rc_job-list]]
-[requirement]
+[requirements_class]
 ====
 [%metadata]
-type:: class
 label:: http://www.opengis.net/spec/ogcapi-processes-1/1.0/req/job-list
 obligation:: requirement
 subject:: Web API

--- a/core/requirements/requirements_class_json.adoc
+++ b/core/requirements/requirements_class_json.adoc
@@ -6,5 +6,5 @@ label:: http://www.opengis.net/spec/ogcapi-processes-1/1.0/req/json
 obligation:: requirement
 subject:: Web API
 inherit:: <<rc_core,OGC API - Processes Core>>
-inherit:: <<JSON,JSON>>
+inherit:: <<rfc8259,JSON>>
 ====

--- a/core/requirements/requirements_class_json.adoc
+++ b/core/requirements/requirements_class_json.adoc
@@ -1,9 +1,7 @@
-
 [[rc_json]]
-[requirement]
+[requirements_class]
 ====
 [%metadata]
-type:: class
 label:: http://www.opengis.net/spec/ogcapi-processes-1/1.0/req/json
 obligation:: requirement
 subject:: Web API

--- a/core/requirements/requirements_class_oas30.adoc
+++ b/core/requirements/requirements_class_oas30.adoc
@@ -1,8 +1,7 @@
 [[rc_oas30]]
-[requirement]
+[requirements_class]
 ====
 [%metadata]
-type:: class
 label:: http://www.opengis.net/spec/ogcapi-processes-1/1.0/req/oas30
 obligation:: requirement
 subject:: Web API

--- a/core/requirements/requirements_class_oas30.adoc
+++ b/core/requirements/requirements_class_oas30.adoc
@@ -8,5 +8,5 @@ obligation:: requirement
 subject:: Web API
 inherit:: <<rc_core,OGC API - Processes 1.0 Core>>
 inherit:: http://www.opengis.net/spec/ogcapi_common-1/1.0/req/oas30[API - Common OpenAPI 3.0]
-inherit:: <<OpenAPI,OpenAPI Specification 3.0.1>>
+inherit:: <<OpenAPI-Spec,OpenAPI Specification 3.0.1>>
 ====

--- a/core/requirements/requirements_class_ogc-process-description.adoc
+++ b/core/requirements/requirements_class_ogc-process-description.adoc
@@ -6,5 +6,5 @@ label:: http://www.opengis.net/spec/ogcapi-processes-1/1.0/req/ogc-process-descr
 obligation:: requirement
 subject:: Web API
 inherit:: <<rc_core,OGC API - Processes Core>>
-inherit:: <<JSON,JSON>>
+inherit:: <<rfc8259,JSON>>
 ====

--- a/core/requirements/requirements_class_ogc-process-description.adoc
+++ b/core/requirements/requirements_class_ogc-process-description.adoc
@@ -1,8 +1,7 @@
 [[rc_ogc-process-description]]
-[requirement]
+[requirements_class]
 ====
 [%metadata]
-type:: class
 label:: http://www.opengis.net/spec/ogcapi-processes-1/1.0/req/ogc-process-description
 obligation:: requirement
 subject:: Web API

--- a/core/sections/annex-bibliography.adoc
+++ b/core/sections/annex-bibliography.adoc
@@ -13,3 +13,6 @@
 * [[[jsonschema-pointers,Relative JSON Pointers]] Hutton, B.: Relative JSON Pointers, https://json-schema.org/draft/2020-12/relative-json-pointer.html
 
 * [[[w3c-html5,W3C HTML 5]]], https://www.w3.org/TR/html5/
+
+* [[[OpenAPI-Spec,OpenAPI Specification 3.0.2]]] Open API Initiative. OpenAPI Specification 3.0.2. Available at:
+https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md.

--- a/core/sections/annex-bibliography.adoc
+++ b/core/sections/annex-bibliography.adoc
@@ -11,3 +11,5 @@
 * [[[jsonschema-validation,JSON Schema Validation]]] Hutton, B.: JSON Schema Validation: A Vocabulary for Structural Validation of JSON, https://json-schema.org/draft/2020-12/json-schema-validation.html
 
 * [[[jsonschema-pointers,Relative JSON Pointers]] Hutton, B.: Relative JSON Pointers, https://json-schema.org/draft/2020-12/relative-json-pointer.html
+
+* [[[w3c-html5,W3C HTML 5]]], https://www.w3.org/TR/html5/

--- a/core/sections/annex-bibliography.adoc
+++ b/core/sections/annex-bibliography.adoc
@@ -2,7 +2,7 @@
 [bibliography]
 == Bibliography
 
-* [[[WFS20,OGC 09-025r2]]] Open Geospatial Consortium (OGC). OGC 09-025r2: **Web Feature Service 2.0** [online]. Edited by P. Vretanos. 2014 [viewed 2020-03-16]. Available at http://docs.opengeospatial.org/is/09-025r2/09-025r2.html
+* [[[WFS20,OGC 09-025r2]]] Open Geospatial Consortium (OGC). OGC 09-025r2: Web Feature Service 2.0 [online]. Edited by P. Vretanos. 2014 [viewed 2020-03-16]. Available at: http://docs.opengeospatial.org/is/09-025r2/09-025r2.html
 
 * [[[ogc15-022,OGC 15-022]]] Matheus, A.: OGC® Testbed 11 Engineering Report: Implementing Common Security Across the OGC Suite of Service Standards, https://portal.opengeospatial.org/files/?artifact_id=63312
 

--- a/core/sections/clause_0_front_material.adoc
+++ b/core/sections/clause_0_front_material.adoc
@@ -38,7 +38,7 @@ Additionally, the /jobs endpoint can be used to grant access to a list of jobs.
 [cols="27,25,10,10,28",options="header"]
 |===
 |Resource |Path |HTTP method | Parameter| Document reference
-|Job list |`/jobs` |GET | N/A |<<Job_list>>
+|Job list |`/jobs` |GET | N/A |<<sc_job_list>>
 |===
 
 In addition to the operations accessible through HTTP GET and POST methods, the DELETE method can be used to cancel a job execution and/or remove traces of the job execution.

--- a/core/sections/clause_10_encodings.adoc
+++ b/core/sections/clause_10_encodings.adoc
@@ -10,8 +10,8 @@ for now, normative statements are often included inline. This will be re-factore
 This clause specifies two pre-defined requirements classes for encodings to be
 used with the OGC API Processes.
 
-* <<rec_json,JSON>>
-* <<rc_html,HTML>>
+* <<sc_requirements_class_json,JSON>>
+* <<sc_requirements_class_html,HTML>>
 
 The JSON encoding is mandatory.
 
@@ -24,16 +24,17 @@ As clients simply need to dereference the URI of the link, the implementation de
 Two common approaches are:
 
 * an additional path for each encoding of each resource (this can be expressed,
-for example, using format specific suffixes like ".html");
+for example, using format specific suffixes like `.html`);
 
 * an additional query parameter (for example, "accept" or "f") that overrides
 the Accept header of the HTTP request.
 ====
 
 The <<rc_core,Core>> requirements class includes recommendations to support
-<<rec_html,HTML>> and <<rec_json,JSON>> as encodings, where practical.
+<<rc_html,HTML>> and <<rc_json,JSON>> as encodings, where practical.
 
 
+[[sc_requirements_class_json]]
 === Requirement Class "JSON"
 
 This section defines the requirements class JSON.

--- a/core/sections/clause_12_job_list.adoc
+++ b/core/sections/clause_12_job_list.adoc
@@ -113,4 +113,4 @@ include::../examples/json/JobList.json[]
 
 See <<http_status_codes>> for general guidance.
 
-If the process with the specified identifier does not exist on the server, the status code of the response SHALL be `404` (see <<req_core_no-such-process>>).
+If the process with the specified identifier does not exist on the server, the status code of the response SHALL be `404` (see <<req_core_process-exception-no-such-process>>).

--- a/core/sections/clause_12_job_list.adoc
+++ b/core/sections/clause_12_job_list.adoc
@@ -1,4 +1,4 @@
-[[Job_list]]
+[[sc_job_list]]
 == Requirements Class "Job list"
 
 === Overview

--- a/core/sections/clause_14_dismiss.adoc
+++ b/core/sections/clause_14_dismiss.adoc
@@ -29,7 +29,7 @@ include::../examples/json/StatusInfo-dismissed.json[]
 
 See <<http_status_codes>> for general guidance.
 
-If the process with the specified identifier does not exist on the server, the status code of the response SHALL be `404` (see <<req_core_no-such-process,/req/core/process-exception/no-such-process>>).
+If the process with the specified identifier does not exist on the server, the status code of the response SHALL be `404` (see <<req_core_process-exception-no-such-process,/req/core/process-exception/no-such-process>>).
 
 If the job with the specified identifier does not exist, the status code of the
 response SHALL be `404` (see <<req_core_job-exception-no-such-job,/req/core/job-results-exception/no-such-job>>).

--- a/core/sections/clause_1_scope.adoc
+++ b/core/sections/clause_1_scope.adoc
@@ -2,5 +2,3 @@
 == Scope
 
 This OGC Standard specifies a Web API that enables the execution of computing processes and the retrieval of metadata describing their purpose and functionality. Typically, these processes combine raster, vector, coverage and/or point cloud data with well-defined algorithms to produce new raster, vector, coverage and/or point cloud information.
-
-

--- a/core/sections/clause_3_references.adoc
+++ b/core/sections/clause_3_references.adoc
@@ -28,4 +28,6 @@
 
 * [[[rfc8288,IETF RFC 8288]]], IETF RFC 8288: Web Linking https://tools.ietf.org/html/rfc8288
 
+* [[[rfc8259,IETF RFC 8259]]], IETF RFC 8259: The JavaScript Object Notation (JSON) Data Interchange Format. Available from: https://tools.ietf.org/html/rfc8259
+
 * [[[jsonschemavalidation,JSON Schema Validation]]] JSON Schema Validation: A Vocabulary for Structural Validation of JSON. https://json-schema.org/draft/2020-12/json-schema-validation.html

--- a/core/sections/clause_6_overview.adoc
+++ b/core/sections/clause_6_overview.adoc
@@ -12,8 +12,6 @@ The OGC API - Processes builds on the WPS 2.0 standard and is modularized. This 
 
 JSON is the encoding for requests and responses. The inputs and outputs of a process can be any format. The formats are defined at the time of job creation and are fixed for the specific job.
 
-<<rec_html,Support for HTML is recommended>> as HTML is the core language of the World Wide Web.
+<<rc_html,Support for HTML>> is recommended as HTML is the core language of the World Wide Web.
 A server that supports HTML will support browsing with a web browser
 and will enable search engines to crawl and index the processes.
-
-

--- a/core/sections/clause_6_overview.adoc
+++ b/core/sections/clause_6_overview.adoc
@@ -2,8 +2,8 @@
 [[overview]]
 == Overview
 
-The OGC API - Processes builds on the WPS 2.0 standard and is modularized. This means that there is a separation between 
- 
+The OGC API - Processes builds on the WPS 2.0 standard and is modularized. This means that there is a separation between
+
 * Core requirements, that specify basic capabilities and can easily be mapped to existing OGC Web Processing Services;
 * More advanced functionality, that is not specified in WPS 2.0.
 

--- a/core/sections/clause_7_core.adoc
+++ b/core/sections/clause_7_core.adoc
@@ -1215,7 +1215,7 @@ The following table maps the possible responses based on the combinations of the
 |200
 |multipart/related
 |[one output per part]
-|<<req_core_process-execute-async-raw-mixed-multi,/req/core/process-execute-async-raw-mixed-multi>>
+|<<req_core_process-execute-sync-raw-mixed-multi,/req/core/process-execute-sync-raw-mixed-multi>>
 
 .3+|document
 .2+|value

--- a/core/sections/clause_7_core.adoc
+++ b/core/sections/clause_7_core.adoc
@@ -1025,7 +1025,7 @@ The following table maps the possible responses based on the combinations of the
 .4+|200
 .4+|application/json
 .4+|https://raw.githubusercontent.com/opengeospatial/ogcapi-processes/master/core/openapi/schemas/results.yaml[results.yaml]
-.4+|<<req_core_process-execute-success-document,/req/core/process-execute-success-document>>
+.4+|<<req_core_process-execute-sync-document,/req/core/process-execute-sync-document>>
 
 |*
 .2+|reference
@@ -1224,7 +1224,7 @@ The following table maps the possible responses based on the combinations of the
 .3+|application/json
 .3+|https://raw.githubusercontent.com/opengeospatial/ogcapi-processes/master/core/openapi/schemas/results.yaml[results.yaml]
 
-.3+|<<req_core_process-execute-success-document,/req/core/process-execute-success-document>>
+.3+|<<req_core_process-execute-sync-document,/req/core/process-execute-sync-document>>
 
 |*
 

--- a/core/sections/clause_7_core.adoc
+++ b/core/sections/clause_7_core.adoc
@@ -279,7 +279,7 @@ Several resources defined in this specification (see <<sc_process_list,Retrieve 
 
 * If the server has any more results available than it returns (the number it returns is less than or equal to the requested/default/maximum limit) then the server will include a link to the next set of results.
 
-So (using the default/maximum values of 10/1000 from the OpenAPI fragment in requirement <<req_core_pl-limit-definition,`/req/core/pl-limit-definition`>> or <<req_job-list_jl-limit-definition,`/req/job-list/jl-limit-definition`>>):
+So (using the default/maximum values of 10/1000 from the OpenAPI fragment in requirement <<req_core_pl-limit-definition,`/req/core/pl-limit-definition`>> or <<req_job-list_limit-definition,`/req/job-list/limit-definition`>>):
 
 * If you ask for 10 results, you will get 0 to 10 (as requested) and if there are more, a `next` link;
 

--- a/core/sections/clause_7_core.adoc
+++ b/core/sections/clause_7_core.adoc
@@ -996,7 +996,8 @@ The following table maps the possible responses based on the combinations of the
 |1
 |200
 |[as per output definition from process description]
-|[output in requested format]| <<req_core_process-execute-sync-raw-value-one,/req/core/process-execute-sync-raw-value-one>>
+|[output in requested format]
+|<<req_core_process-execute-sync-raw-value-one,/req/core/process-execute-sync-raw-value-one>>
 |*
 
 |200

--- a/core/sections/clause_7_core.adoc
+++ b/core/sections/clause_7_core.adoc
@@ -1093,7 +1093,7 @@ include::../requirements/core/REQ_process-execute-success-async.adoc[]
 
 See <<http_status_codes>> for general guidance.
 
-If the process with the specified identifier does not exist on the server, see requirement <<req_core_no-such-process,/req/core/process-exception/no-such-process>>.
+If the process with the specified identifier does not exist on the server, see requirement <<req_core_process-exception-no-such-process,/req/core/process-exception/no-such-process>>.
 
 
 [[sc_retrieve_status_info]]
@@ -1148,7 +1148,7 @@ include::../examples/json/StatusInfo.json[]
 
 See <<http_status_codes>> for general guidance.
 
-If the process with the specified identifier does not exist on the server, see requirement <<req_core_no-such-process,/req/core/process-exception/no-such-process>>.
+If the process with the specified identifier does not exist on the server, see requirement <<req_core_process-exception-no-such-process,/req/core/process-exception/no-such-process>>.
 
 include::../requirements/core/REQ_job-exception-no-such-job.adoc[]
 

--- a/core/sections/clause_9_security-considerations.adoc
+++ b/core/sections/clause_9_security-considerations.adoc
@@ -35,7 +35,7 @@ Requirements class "Core":
 
 Requirements class "Job list"
 
-* <<Job_list,list>>
+* <<sc_job_list,list>>
 
 The following API operations use unsafe HTTP methods, modify resources and therefore require special attention:
 

--- a/extensions/transactions/standard/requirements/requirements_class_ogcapppkg.adoc
+++ b/extensions/transactions/standard/requirements/requirements_class_ogcapppkg.adoc
@@ -1,8 +1,7 @@
 [[rc_ogcapppkg]]
-[requirement]
+[requirements_class]
 ====
 [%metadata]
-type:: class
 label:: http://www.opengis.net/spec/ogcapi-processes-2/1.0/req/transactions/ogcapppkg
 obligation:: requirement
 subject:: Web API

--- a/extensions/transactions/standard/requirements/requirements_class_transactions.adoc
+++ b/extensions/transactions/standard/requirements/requirements_class_transactions.adoc
@@ -1,8 +1,7 @@
 [[rc_transactions]]
-[requirement]
+[requirements_class]
 ====
 [%metadata]
-type:: class
 label:: http://www.opengis.net/spec/ogcapi-processes-2/1.0/req/transactions
 obligation:: requirement
 subject:: Web API

--- a/extensions/transactions/standard/sections/annex_bibliography.adoc
+++ b/extensions/transactions/standard/sections/annex_bibliography.adoc
@@ -5,5 +5,5 @@
 
 * [[[OAFeat-Guide,1]]] Heazel, Ch.: *Guide to OGC API - Features*, https://example.org/fixme
 
-* [[[OpenAPI,2]]] Open API Initiative: *OpenAPI Specification 3.0.2*,
-https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md
+* [[[OpenAPI-Spec,OpenAPI Specification 3.0.2]]] Open API Initiative. OpenAPI Specification 3.0.2. Available at:
+https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md.

--- a/extensions/transactions/standard/sections/clause_0_front_material.adoc
+++ b/extensions/transactions/standard/sections/clause_0_front_material.adoc
@@ -2,7 +2,7 @@
 [abstract]
 == Abstract
 
-OGC API standards define modular API building blocks to spatially enable Web APIs in a consistent way. The <<OpenAPI,OpenAPI specification>> is used to define the API building blocks.
+OGC API standards define modular API building blocks to spatially enable Web APIs in a consistent way. The <<OpenAPI-Spec,OpenAPI specification>> is used to define the API building blocks.
 
 OGC API Processes provides API building blocks to describe, execute, monitor
 and retrieve results of Web-accessible processes.  OGC API Processes is

--- a/extensions/workflows/standard/requirements/requirements_class_workflows.adoc
+++ b/extensions/workflows/standard/requirements/requirements_class_workflows.adoc
@@ -1,8 +1,7 @@
 [[rc_workflows]]
-[requirement]
+[requirements_class]
 ====
 [%metadata]
-type:: class
 label:: http://www.opengis.net/spec/ogcapi-processes-3/1.0/req/workflows
 obligation:: requirement
 subject:: Web API

--- a/extensions/workflows/standard/sections/annex_bibliography.adoc
+++ b/extensions/workflows/standard/sections/annex_bibliography.adoc
@@ -1,8 +1,8 @@
 
-[[Bibliography]]
 [bibliography]
 == Bibliography
 
 * [[[OAFeat-Guide,1]]] Heazel, Ch.: *Guide to OGC API - Features*, https://example.org/fixme
-* [[[OpenAPI,2]]] Open API Initiative: *OpenAPI Specification 3.0.2*,
-https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md
+
+* [[[OpenAPI-Spec,OpenAPI Specification 3.0.2]]] Open API Initiative. OpenAPI Specification 3.0.2. Available at:
+https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md.

--- a/extensions/workflows/standard/sections/clause_0_front_material.adoc
+++ b/extensions/workflows/standard/sections/clause_0_front_material.adoc
@@ -2,7 +2,7 @@
 [abstract]
 == Abstract
 
-OGC API standards define modular API building blocks to spatially enable Web APIs in a consistent way. The <<OpenAPI,OpenAPI specification>> is used to define the API building blocks.
+OGC API standards define modular API building blocks to spatially enable Web APIs in a consistent way. The <<OpenAPI-Spec,OpenAPI specification>> is used to define the API building blocks.
 
 OGC API Processes provides API building blocks to describe, execute, monitor
 and retrieve results of Web-accessible processes.  OGC API Processes is


### PR DESCRIPTION
There are a large number missing anchors in this document, and quite a few cannot be resolved since the content does not (or no longer) exist in the document.

Many links are now fixed, but the following remain.

### link-relations is undefined

```adoc
The following <<link-relations,registered link relation types>> are used in this document.
```

This link does not seem to serve any purpose.


### ats_core_job-creation-success-header-async is undefined

```adoc
Validate the HTTP headers of the results using the test 
<<ats_core_job-creation-success-header-async,/conf/core/job-creation-success-header-async>>.
```

This test is not defined anywhere

### ats_geojson_content is undefined


> ```
> |JSON |link:http://schemas.opengis.net/ogcapi/processes/part1/1.0/openapi/schemas/landingPage.yaml[landingPage.yaml]
> |<<ats_geojson_content,/conf/geojson/content>>
> ```

There is no geojson related requirement/test in this document.


### req_core_job-results-sync is undefined

Can't find anything similar.

### sc_process_outputs-value-schema is undefined

There is a `sc_process_outputs` section but nothing about the value schema.


### `req_core_job-creation-{*}`

These seem to have been replaced by `req_core_job-results-{*}`.

req_core_job-creation-async-document is undefined
req_core_job-creation-async-raw-mixed-multi is undefined
req_core_job-creation-async-raw-ref is undefined
req_core_job-creation-async-raw-value-multi is undefined
req_core_job-creation-async-raw-value-one is undefined
req_core_job-creation-auto-execution-mode is undefined
req_core_job-creation-default-execution-mode is undefined
req_core_job-creation-input-array is undefined
req_core_job-creation-input-inline is undefined
req_core_job-creation-input-inline-bbox is undefined
req_core_job-creation-input-inline-binary is undefined
req_core_job-creation-input-inline-mixed is undefined
req_core_job-creation-input-inline-object is undefined
req_core_job-creation-input-ref is undefined
req_core_job-creation-input-validation is undefined
req_core_job-creation-inputs is undefined
req_core_job-creation-op is undefined
req_core_job-creation-request is undefined
req_core_job-creation-success-async is undefined
req_core_job-creation-sync-document is undefined
req_core_job-creation-sync-raw-mixed-multi is undefined
req_core_job-creation-sync-raw-ref is undefined
req_core_job-creation-sync-raw-value-multi is undefined
req_core_job-creation-sync-raw-value-one is undefined
req_core_job-creations-input-array is undefined
req_core_job-creations-input-binary is undefined
req_core_job-creations-input-inline is undefined

### ats_json_content

Doesn't exist. There is a `ats_http_content`, but the corresponding JSON version is missing.

------

### Pending investigation

```
_json is undefined
```


UPDATED 20211018.